### PR TITLE
Correction of various errors, add global var

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -1,13 +1,16 @@
 { config
 , pkgs
 , modulesPath
+, inputs
 , ...
-}@attrs:
+}:
 
 # If used without a flake we can't declare nixos-hardware in the inputs
 # or the configuration will fail to evaulate.
-let nixos-hardware = attrs.nixos-hardware or
-      (builtins.fetchGit { url = "https://github.com/nixos/nixos-hardware"; });
+let 
+  # nixos-hardware = attrs.nixos-hardware or
+  #     (builtins.fetchGit { url = "https://github.com/nixos/nixos-hardware"; });
+  nixos-hardware = inputs.nixos-hardware;
 in
 
 {
@@ -17,6 +20,7 @@ in
     # to minimize rebuilds.
     "${modulesPath}/installer/cd-dvd/channel.nix"
     #./nix-cfgs/builder.nix
+    inputs.home-manager.nixosModules.home-manager
   ];
 
   system.stateVersion = "24.05";
@@ -115,8 +119,8 @@ in
         backupFileExtension = "hm-bak";
         useGlobalPkgs = true;
 
-        config =
-            { config, lib, pkgs, ... }:
+        users.nixos =
+            { config, lib, pkgs, inputs, ... }:
             {
             # Read the changelog before changing this value
             home.stateVersion = "24.05";
@@ -124,10 +128,10 @@ in
             # insert home-manager config
             imports = [
                 ./home-cfgs/bash.nix
-                ./home-cfgs/home-mgr.nix
+                # ./home-cfgs/home-mgr.nix
                 ./home-cfgs/user-pkgs.nix
                 ./home-cfgs/nvim.nix
-                ./home-cfgs/git.com
+                ./home-cfgs/git.nix
             ];
         };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,7 @@
   inputs = {
     nixpkgs = {
         url = "github:nixos/nixpkgs/nixos-24.05";
-        inputs.home-manager.follows = "home-manager";
-
+        # inputs.home-manager.follows = "home-manager";
     };
 
     nixos-hardware.url = "github:nixos/nixos-hardware";
@@ -14,7 +13,7 @@
     };
   };
 
-  outputs = { self, nixpkgs, nixos-hardware, home-manager, ... }:
+  outputs = { self, nixpkgs, nixos-hardware, home-manager, ... }@inputs:
     let
       supportedSystems = [
         "x86_64-linux"
@@ -41,11 +40,11 @@
       };
 
       nixosConfigurations.star64 = nixpkgs.lib.nixosSystem {
-        specialArgs = { inherit nixos-hardware; };
+        specialArgs = { inherit inputs; };
         modules = [ nixosModules.star64 nixosModules.copyConfiguration ];
       };
       nixosConfigurations.star64-8gb = nixpkgs.lib.nixosSystem {
-        specialArgs = { inherit nixos-hardware; };
+        specialArgs = { inherit inputs; };
         modules = [ nixosModules.star64 nixosModules.copyConfiguration nixosModules."8gb-patch" ];
       };
 
@@ -54,7 +53,7 @@
         sd-image = nixosConfigurations.star64.config.system.build.sdImage;
         sd-image-8gb = nixosConfigurations.star64-8gb.config.system.build.sdImage;
         sd-image-cross = (nixpkgs.lib.nixosSystem {
-          specialArgs = { inherit nixos-hardware; };
+          specialArgs = { inherit inputs; };
           modules = [
             nixosModules.star64
             nixosModules.copyConfiguration
@@ -62,7 +61,7 @@
           ];
         }).config.system.build.sdImage;
         sd-image-cross-8gb = (nixpkgs.lib.nixosSystem {
-          specialArgs = { inherit nixos-hardware; };
+          specialArgs = { inherit inputs; };
           modules = [
             nixosModules.star64
             nixosModules.copyConfiguration

--- a/home-cfgs/git.nix
+++ b/home-cfgs/git.nix
@@ -1,6 +1,6 @@
 { config, lib, pkgs, ... }:
 {
-    programs.gitMinimal = {
+    programs.git = {
         enable = true;
         userName = "<username>";
         userEmail = "<email>";


### PR DESCRIPTION
- Add an `inputs` variable to allow all inputs to be imported in a single declaration. 
- Fixed incorrect input.
- Fixed a typo when importing `git.nix` (formerly `git.com`).


Not fixed: 

The configured user is `nixos` but one of the configurations imported via `home-manager` is called `spid`. 

Patch problem during build (due to update 24.05)